### PR TITLE
Experimental new architecture for sky and lfc

### DIFF
--- a/tests/test_hpf.py
+++ b/tests/test_hpf.py
@@ -114,8 +114,15 @@ def test_sky_and_lfc():
     )
     assert np.median(new_spec2.flux.value) == 1.0
 
-    # Known regression: this should not be enabled, but it's harmless
-    assert spec.sky == spec.sky.sky
+    # The sky/lfc fibers should not have their own sky/lfc fibers: that's redundant
+    assert "sky" not in spec.sky.meta.keys()
+    assert "lfc" not in spec.sky.meta.keys()
+    assert "sky" not in spec.lfc.meta.keys()
+    assert "lfc" not in spec.lfc.meta.keys()
+
+    assert spec.lfc.meta["provenance"] == "Laser Frequency Comb"
+    assert spec.sky.meta["provenance"] == "Sky fiber"
+    assert spec.meta["provenance"] == "Target fiber"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_hpf.py
+++ b/tests/test_hpf.py
@@ -80,6 +80,38 @@ def test_uncertainty():
     assert np.isclose(snr_med, snr_old_med, atol=0.005)
 
 
+def test_sky_and_lfc():
+    """Do we track sky and lfc?"""
+
+    spec = HPFSpectrum(file=file, order=10)
+
+    assert spec.sky is not None
+    assert isinstance(spec.sky, Spectrum1D)
+    assert spec.lfc is not None
+    assert isinstance(spec.lfc, Spectrum1D)
+    assert hasattr(spec.sky, "flux")
+    assert isinstance(spec.sky.flux, np.ndarray)
+    assert len(spec.sky.flux) == len(spec.flux)
+    assert spec.flux.unit == spec.sky.unit
+
+    new_spec = spec.remove_nans()
+
+    assert new_spec.sky is not None
+    assert hasattr(new_spec.sky, "flux")
+
+    new_spec2 = new_spec.normalize()
+
+    assert new_spec2.sky is not None
+    assert isinstance(new_spec2.sky, Spectrum1D)
+    assert hasattr(new_spec2.sky, "flux")
+
+    # Normalize should scale both target and sky flux by the same scalar
+    assert np.nanmedian(new_spec2.sky.flux.value) != np.nanmedian(
+        new_spec.sky.flux.value
+    )
+    assert np.median(new_spec2.flux.value) == 1.0
+
+
 @pytest.mark.parametrize(
     "precache_hdus", [True, False],
 )

--- a/tests/test_hpf.py
+++ b/tests/test_hpf.py
@@ -87,8 +87,11 @@ def test_sky_and_lfc():
 
     assert spec.sky is not None
     assert isinstance(spec.sky, Spectrum1D)
+    assert spec.sky == spec.meta["sky"]
+
     assert spec.lfc is not None
     assert isinstance(spec.lfc, Spectrum1D)
+
     assert hasattr(spec.sky, "flux")
     assert isinstance(spec.sky.flux, np.ndarray)
     assert len(spec.sky.flux) == len(spec.flux)
@@ -110,6 +113,9 @@ def test_sky_and_lfc():
         new_spec.sky.flux.value
     )
     assert np.median(new_spec2.flux.value) == 1.0
+
+    # Known regression: this should not be enabled, but it's harmless
+    assert spec.sky == spec.sky.sky
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Issue #10 asks how to address the sky and lfc fibers.  This PR takes a stab at it in the following way:

We make an `HPFSpectrum` for each of the target, sky, and lfc.  The target spectrum is returned by default, and we put the `sky` and `lfc` in `meta` so that you can access it by saying:

```python
spectrum.meta['sky']
# or through a convenience property:
spectrum.sky
```
I think this solution satisfies the goal of get all the HPF spectrum in one-fell-swoop, and it allows us to make custom methods that apply to all attributes.  See `normalize` for an example.

One demerit of this approach is that it makes implementing methods a little more verbose/tricky since we have to consider the sky and lfc metadata.  Maybe that's unavoidable!  I'd be curious what the specutils developers think of my abuse of `meta`, or if there's a better way.
