### PR TITLE
Astropy 5 dropped support for python 3.7, exclude it in build matrix

### DIFF
--- a/.github/workflows/muler-tests.yml
+++ b/.github/workflows/muler-tests.yml
@@ -17,6 +17,10 @@ jobs:
           - python-version: "3.6"
             astropy-version: "4.1"
             specutils-version: "1.3.1"
+        exclude:
+        # Astropy 5 drops support for python 3.7
+          - python-version: "3.7"
+            astropy-version: "5.0"
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Should fix the failing builds...