### PR TITLE
Possibly a fix for #94-- unit issue stemed from ancillary data miscue

### DIFF
--- a/src/muler/echelle.py
+++ b/src/muler/echelle.py
@@ -840,9 +840,23 @@ class EchelleSpectrumList(SpectrumList):
             fluxes_anc = np.hstack(
                 [spec[i].meta[ancillary_spectrum].flux for i in range(len(spec))]
             )
+            if spec[0].meta[ancillary_spectrum].uncertainty is not None:
+                # HACK We assume if one order has it, they all do, and that it's StdDev
+                unc_anc = np.hstack(
+                    [
+                        spec[i].meta[ancillary_spectrum].uncertainty.array
+                        for i in range(len(self))
+                    ]
+                )
+                unc_anc = StdDevUncertainty(unc_anc)
+            else:
+                unc_anc = None
 
             meta_out[ancillary_spectrum] = spec[0].__class__(
-                spectral_axis=wls_anc, flux=fluxes_anc, meta=meta_of_meta
+                spectral_axis=wls_anc,
+                flux=fluxes_anc,
+                uncertainty=unc_anc,
+                meta=meta_of_meta,
             )
 
         return spec[0].__class__(

--- a/src/muler/echelle.py
+++ b/src/muler/echelle.py
@@ -70,7 +70,7 @@ class EchelleSpectrum(Spectrum1D):
 
     def __init__(self, *args, **kwargs):
 
-        self.ancillary_spectra = None
+        # self.ancillary_spectra = None
         super().__init__(*args, **kwargs)
 
     @property
@@ -92,6 +92,11 @@ class EchelleSpectrum(Spectrum1D):
             snr_estimate = np.repeat(np.NaN, len(self.flux)) * u.dimensionless_unscaled
 
         return snr_estimate
+
+    @property
+    def ancillary_spectra(self):
+        """The list of conceivable ancillary spectra"""
+        return []
 
     @property
     def available_ancillary_spectra(self):
@@ -704,7 +709,6 @@ class EchelleSpectrumList(SpectrumList):
     def __init__(self, *args, **kwargs):
         self.normalization_order_index = 0
         super().__init__(*args, **kwargs)
-
 
     def normalize(self, order_index=None):
         """Normalize all orders to one of the other orders

--- a/src/muler/hpf.py
+++ b/src/muler/hpf.py
@@ -73,7 +73,7 @@ class HPFSpectrum(EchelleSpectrum):
     def __init__(self, *args, file=None, order=19, cached_hdus=None, **kwargs):
 
         self.site_name = "mcdonald"
-        self.ancillary_spectra = ["sky", "lfc"]
+        # self.ancillary_spectra = ["sky", "lfc"]
         self.noisy_edges = (3, 2045)
         self.instrumental_resolution = 55_000.0
 
@@ -202,6 +202,11 @@ class HPFSpectrum(EchelleSpectrum):
     def lfc(self):
         """Sky fiber spectrum stored as its own HPFSpectrum object"""
         return self.meta["lfc"]
+
+    @property
+    def ancillary_spectra(self):
+        """The list of conceivable ancillary spectra"""
+        return ["sky", "lfc"]
 
     @property
     def RA(self):

--- a/src/muler/igrins.py
+++ b/src/muler/igrins.py
@@ -59,7 +59,7 @@ class IGRINSSpectrum(EchelleSpectrum):
         self, *args, file=None, order=10, cached_hdus=None, wavefile=None, **kwargs
     ):
 
-        self.ancillary_spectra = None
+        # self.ancillary_spectra = None
         self.noisy_edges = (450, 1950)
         self.instrumental_resolution = 45_000.0
 
@@ -148,6 +148,11 @@ class IGRINSSpectrum(EchelleSpectrum):
         return self.meta["header"]["TELESCOP"]
 
     @property
+    def ancillary_spectra(self):
+        """The list of conceivable ancillary spectra"""
+        return []
+
+    @property
     def RA(self):
         """The right ascension from header files"""
         return self.meta["header"]["OBJRA"] * u.deg
@@ -201,7 +206,7 @@ class IGRINSSpectrumList(EchelleSpectrumList):
         n_orders, n_pix = hdus[0].data.shape
 
         list_out = []
-        for i in range(n_orders-1, -1, -1):
+        for i in range(n_orders - 1, -1, -1):
             spec = IGRINSSpectrum(
                 file=file, wavefile=wavefile, order=i, cached_hdus=cached_hdus
             )

--- a/src/muler/nirspec.py
+++ b/src/muler/nirspec.py
@@ -53,7 +53,7 @@ class KeckNIRSPECSpectrum(EchelleSpectrum):
     def __init__(self, *args, file=None, order=63, **kwargs):
 
         self.site_name = "Keck Observatory"
-        self.ancillary_spectra = ["sky"]
+        # self.ancillary_spectra = ["sky"]
         self.noisy_edges = (10, 1000)
         self.instrumental_resolution = 20_000.0
 
@@ -142,6 +142,11 @@ class KeckNIRSPECSpectrum(EchelleSpectrum):
     def sky(self):
         """Sky fiber spectrum stored as its own KeckNIRSPECSpectrum object"""
         return self.meta["sky"]
+
+    @property
+    def ancillary_spectra(self):
+        """The list of conceivable ancillary spectra"""
+        return ["sky"]
 
     @property
     def flat(self):


### PR DESCRIPTION
I tracked down an bug where the "ancillary_metadata" list was not being passed through.  I moved this attribute from the `__init__` to becoming a property, which appears to have solved the problem.  🤷🏻‍♂️

It should fix the sky subtraction miscue, which stemed from the sky fiber not getting normalized.