### PR TITLE
Attempting to fix issues propogating uncertainity

### DIFF
--- a/src/muler/igrins.py
+++ b/src/muler/igrins.py
@@ -128,7 +128,7 @@ class IGRINSSpectrum(EchelleSpectrum):
                         wave_hdus = fits.open(full_path)
                 if "rtell" not in file:  
                     uncertainty_filepath = getUncertainityFilepath(file)
-                    uncertainity_hdus = fits.open(uncertainityFilepath, memmap=False)   
+                    uncertainity_hdus = fits.open(uncertainty_filepath, memmap=False)   
                     if '.sn.fits' in uncertainty_filepath:
                         sn_used = True
                 else: #If rtell file is used, grab SNR stored in extension

--- a/src/muler/igrins.py
+++ b/src/muler/igrins.py
@@ -155,7 +155,7 @@ class IGRINSSpectrum(EchelleSpectrum):
                     pixel_per_res_element = (lamb/40000.)/dw
                     sn_per_pixel =  sn / np.sqrt(pixel_per_res_element)
                     stddev = flux.value / sn_per_pixel.value
-                uncertainty = StdDevUncertainty(stddev)
+                uncertainty = StdDevUncertainty(np.abs(stddev))
                 mask = np.isnan(flux) | np.isnan(uncertainty.array)
             else:
                 uncertainity = None


### PR DESCRIPTION
This is partly a follow up to fix issues from the previous pull request https://github.com/OttoStruve/muler/pull/89

There were a few issues involving error propagation that needed to be fixed.
-  Grabbing a sn.fits file if a variance.files file does not exist and converting from the SNR per resolution to SNR per pixel.  
-  Re-scaling the stddev for spec_a0v.fits and rtell files such that the SNR is preserved (NOTE: rtell files recalculate the SNR to include scaling by the standard star, so it is equal to or lower than what you would expect for the science target spectrum only, this can happen if the SNR is lower for the standard star than the science target).